### PR TITLE
Add batch throughput reporting and quiet cron run

### DIFF
--- a/batchcheck_cron.sh
+++ b/batchcheck_cron.sh
@@ -11,4 +11,4 @@ cd /home/languageingenetics/Word-Frequency-Analysis-/extractor
 export PGDATABASE=crossref
 
 # Run batch check
-uv run batchcheck.py
+uv run batchcheck.py --quiet


### PR DESCRIPTION
## Summary
- add a quiet mode and throughput estimation to `batchcheck.py`
- update the cron wrapper to rely on the quiet batch check mode
- surface recent articles-per-hour metrics through the dashboard API and UI

## Testing
- python3 -m compileall extractor/batchcheck.py extractor/dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68df875326188325b57d869bec3f691f