### PR TITLE
Increase daily article batch size

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,12 +151,12 @@ crontab -e
 
 The script performs these steps:
 1. Fetches completed OpenAI batch results
-2. Submits a new batch of articles for processing (default: 1000 articles)
+2. Submits a new batch of articles for processing (default: 4000 articles)
 3. Generates static HTML dashboard
 4. Syncs dashboard to remote server via rsync
 
 **Configuration** (edit cronscript.sh):
-- `BATCH_SIZE`: Number of articles to process per batch (default: 1000)
+- `BATCH_SIZE`: Number of articles to process per batch (default: 4000)
 - `REMOTE_HOST`: Server to sync dashboard to
 - `REMOTE_PATH`: Path on remote server
 

--- a/cronscript.sh
+++ b/cronscript.sh
@@ -7,7 +7,7 @@ WORKDIR="/home/languageingenetics/Word-Frequency-Analysis-"
 DASHBOARD_DIR="$WORKDIR/dashboard"
 REMOTE_HOST="merah.cassia.ifost.org.au"
 REMOTE_PATH="/var/www/vhosts/lig.symmachus.org/htdocs/"
-BATCH_SIZE=2000
+BATCH_SIZE=4000
 LOG_FILE="$WORKDIR/cronscript.log"
 
 # PostgreSQL connection uses environment variables


### PR DESCRIPTION
## Summary
- double the automated daily batch size to process 4000 articles per run
- update contributor documentation to reflect the new default batch size

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebab1c33988325ab15cdfdc4fc2564