### PR TITLE
Persist batch diagnostics and expose dashboard detail view

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,13 +1,25 @@
 create table if not exists raw_text_data (id serial primary key, filesrc text);
 
 create materialized view if not exists raw_json_data as
- with cleanup as ( 
+ with cleanup as (
   select id,
-    regexp_replace( 
+    regexp_replace(
        regexp_replace(filesrc, E'\n', ' ', 'g'),
              E'\t', '    ', 'g')
        as clean_text from raw_text_data)
   select id, clean_text::jsonb from cleanup
    where clean_text is json;
+
+create table if not exists languageingenetics.batch_diagnostics (
+    id bigserial primary key,
+    batch_id int not null references languageingenetics.batches(id) on delete cascade,
+    article_id int,
+    event_type text not null,
+    details jsonb,
+    created_at timestamptz not null default current_timestamp
+);
+
+create index if not exists batch_diagnostics_batch_id_idx
+    on languageingenetics.batch_diagnostics (batch_id);
 
 


### PR DESCRIPTION
## Summary
- create a languageingenetics.batch_diagnostics table to store per-article diagnostic events
- record submission/skip details and per-run totals from the batch builder into the new table
- extend the dashboard generator with a linked diagnostics page that visualizes the stored reasons

## Testing
- python -m compileall -f extractor/bulkquery.py
- python -m compileall -f extractor/generate_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68f634e228448325ab794d70293f5464