### PR TITLE
Add stacked terminology share chart to dashboard

### DIFF
--- a/extractor/generate_dashboard.py
+++ b/extractor/generate_dashboard.py
@@ -890,7 +890,7 @@ html_content += f"""
                         tooltip: {
                             callbacks: {
                                 label: context => {
-                                    const value = typeof context.parsed.y === 'number' ? context.parsed.y : 0;
+                                    const value = typeof context.raw === 'number' ? context.raw : 0;
                                     return context.dataset.label + ': ' + (value * 100).toFixed(2) + '%';
                                 }
                             }


### PR DESCRIPTION
## Summary
- compute yearly racial terminology totals and derive a proportion dataset for charting
- render a stacked area chart on the dashboard to show the share of each terminology among yearly racial references

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690a86b255a083258ac4a7d3ce80ff83